### PR TITLE
fix(PT-12602):  type-cast config values and params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 .phpunit.result.cache
 .php-cs-fixer.cache
+.psh.yml.override

--- a/Components/ValidationService.php
+++ b/Components/ValidationService.php
@@ -378,14 +378,16 @@ class ValidationService implements ValidationServiceInterface
      */
     private function getEmailAddress()
     {
-        $emailNotification = $this->config->get(VatIdConfigReaderInterface::EMAIL_NOTIFICATION);
+        $emailNotification = (string) $this->config->get(VatIdConfigReaderInterface::EMAIL_NOTIFICATION);
 
-        if (\is_string($emailNotification)) {
-            $emailAddress = $emailNotification;
-        } elseif ($emailNotification) {
+        if ($emailNotification === '0') {
+            return false;
+        }
+
+        if ($emailNotification === '1') {
             $emailAddress = $this->config->get('sMAIL');
         } else {
-            return false;
+            $emailAddress = $emailNotification;
         }
 
         return \filter_var($emailAddress, \FILTER_VALIDATE_EMAIL);

--- a/Components/VatIdValidatorResult.php
+++ b/Components/VatIdValidatorResult.php
@@ -272,7 +272,7 @@ class VatIdValidatorResult implements \Serializable
         $this->init($serializeArray['namespace']);
 
         foreach ($serializeArray['keys'] as $errorCode) {
-            $this->addError($errorCode);
+            $this->addError((string) $errorCode);
         }
     }
 

--- a/Tests/Functional/Components/VatIdValidatorResultTest.php
+++ b/Tests/Functional/Components/VatIdValidatorResultTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 /**
  * (c) shopware AG <info@shopware.com>
@@ -62,6 +63,48 @@ class VatIdValidatorResultTest extends TestCase
 
         static::assertFalse($validatorResult->isValid());
         static::assertEmpty($validatorResult->getErrorMessages());
+    }
+
+    /**
+     * @dataProvider provideVatIdValidatorResults
+     *
+     * @param array<int, mixed>  $errorCodes
+     * @param array<int, string> $expectedErrorMessages
+     */
+    public function testAddErrorCodesWillNotThrowAnError(string $serializedVatIdValidatorResult, array $errorCodes, array $expectedErrorMessages): void
+    {
+        $validatorResult = $this->createVatIdValidatorResult();
+        $validatorResult->unserialize($serializedVatIdValidatorResult);
+
+        static::assertFalse($validatorResult->isValid());
+
+        $errorMessages = $validatorResult->getErrorMessages();
+
+        $counter = 0;
+        foreach ($errorMessages as $errorCode => $errorMessage) {
+            static::assertSame($errorCodes[$counter], $errorCode);
+            static::assertSame($expectedErrorMessages[$counter], $errorMessage);
+
+            ++$counter;
+        }
+    }
+
+    /**
+     * @return \Generator<array{serializedVatIdValidatorResult: string, errorCodes: array<int, mixed>, expectedErrorMessages: array<int, string>}>
+     */
+    public function provideVatIdValidatorResults(): \Generator
+    {
+        yield 'existing VatId is invalid but required' => [
+            'serializedVatIdValidatorResult' => 'a:2:{s:9:"namespace";s:13:"miasValidator";s:4:"keys";a:2:{i:0;i:1;i:1;s:8:"required";}}',
+            'errorCodes' => [
+                1,
+                'required',
+            ],
+            'expectedErrorMessages' => [
+                'Die angefragte USt-IdNr. ist ungültig.',
+                'Sie haben gegenwärtig keine USt-IdNr. angegeben. Bitte tragen Sie sie in Ihrem Account nach.',
+            ],
+        ];
     }
 
     private function createVatIdValidatorResult(): VatIdValidatorResult

--- a/Tests/Functional/Components/VatIdValidatorResultTest.php
+++ b/Tests/Functional/Components/VatIdValidatorResultTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 namespace SwagVatIdValidation\Tests\Functional\Components;
 
 use PHPUnit\Framework\TestCase;
-use Shopware\Components\DependencyInjection\Container;
 use Shopware_Components_Config as ShopwareConfig;
 use SwagVatIdValidation\Components\VatIdConfigReaderInterface;
 use SwagVatIdValidation\Components\VatIdValidatorResult;
@@ -20,20 +19,29 @@ class VatIdValidatorResultTest extends TestCase
 {
     use ContainerTrait;
 
+    private const DEFAULT_CONFIG_ALLOW_REGISTER_ON_API_ERROR = false;
+
+    /**
+     * @var ShopwareConfig
+     */
+    private $config;
+
+    /**
+     * @before
+     */
+    public function setUp(): void
+    {
+        $this->config = $this->getContainer()->get('config');
+    }
+
     public function testSetServiceUnavailable(): void
     {
-        $container = $this->getContainer();
-        static::assertInstanceOf(Container::class, $container);
-
-        $config = $container->get('config');
-        static::assertInstanceOf(ShopwareConfig::class, $config);
-
-        $config->offsetSet(VatIdConfigReaderInterface::ALLOW_REGISTER_ON_API_ERROR, false);
+        $this->config->offsetSet(VatIdConfigReaderInterface::ALLOW_REGISTER_ON_API_ERROR, false);
 
         $validatorResult = $this->createVatIdValidatorResult();
         $validatorResult->setServiceUnavailable();
 
-        $container->reset('config');
+        $this->config->offsetSet(VatIdConfigReaderInterface::ALLOW_REGISTER_ON_API_ERROR, self::DEFAULT_CONFIG_ALLOW_REGISTER_ON_API_ERROR);
 
         static::assertFalse($validatorResult->isValid());
         static::assertNotEmpty($validatorResult->getErrorMessages());
@@ -45,18 +53,12 @@ class VatIdValidatorResultTest extends TestCase
 
     public function testSetServiceUnavailableExpectNoErrorMessage(): void
     {
-        $container = $this->getContainer();
-        static::assertInstanceOf(Container::class, $container);
-
-        $config = $container->get('config');
-        static::assertInstanceOf(ShopwareConfig::class, $config);
-
-        $config->offsetSet(VatIdConfigReaderInterface::ALLOW_REGISTER_ON_API_ERROR, true);
+        $this->config->offsetSet(VatIdConfigReaderInterface::ALLOW_REGISTER_ON_API_ERROR, true);
 
         $validatorResult = $this->createVatIdValidatorResult();
         $validatorResult->setServiceUnavailable();
 
-        $container->reset('config');
+        $this->config->offsetSet(VatIdConfigReaderInterface::ALLOW_REGISTER_ON_API_ERROR, self::DEFAULT_CONFIG_ALLOW_REGISTER_ON_API_ERROR);
 
         static::assertFalse($validatorResult->isValid());
         static::assertEmpty($validatorResult->getErrorMessages());

--- a/plugin.xml
+++ b/plugin.xml
@@ -11,6 +11,15 @@
     <author>Shopware AG</author>
     <compatibility minVersion="5.6.0" maxVersion="5.99.99"/>
 
+    <changelog version="REPLACE_GLOBALLY_WITH_NEXT_VERSION(2.0.10)">
+        <changes lang="de">
+            PT-12602 - Einstellungen für "eMail-Benachrichtigung" werden wieder korrekt ausgewertet;
+        </changes>
+        <changes lang="en">
+            PT-12602 - Settings for "eMail notification" are processed correctly again;
+        </changes>
+    </changelog>
+
     <changelog version="2.0.9">
         <changes lang="de">PT-12589 - Fehlverhalten bei Validierung von ungültiger ID korrigiert;</changes>
         <changes lang="en">PT-12589 - Fix error during validation of invalid ID;</changes>


### PR DESCRIPTION
Avoid "TypeError" issues when passing integers to the function
Adjust getEmailAddress() to handle strings. Otherwise, email notifications are never sent.